### PR TITLE
Make tests compatible with sphinx 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python:
   - 3.5
   - 3.6
+env:
+  - SPHINX_VERSION="<1.6"
+  - SPHINX_VERSION=">=1.6"
 sudo: false
 dist: trusty
 

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -3,6 +3,7 @@
 set -exu -o pipefail
 
 pip install -U pip setuptools wheel
+pip install "sphinx ${SPHINX_VERSION}"
 
 python setup.py sdist --formats=zip
 pip install dist/*.zip


### PR DESCRIPTION
It started converting "..." to ellipsis characters, which confused our
test suite.