### PR TITLE
Add a monkey-patch to VariableCommentPicker to make auto_member_order work.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 3.5
   - 3.6
 env:
-  - SPHINX_VERSION="<1.6"
+  - SPHINX_VERSION="~=1.6"
   - SPHINX_VERSION=">=1.6"
 sudo: false
 dist: trusty

--- a/newsfragments/13.bugfix.rst
+++ b/newsfragments/13.bugfix.rst
@@ -1,0 +1,1 @@
+Fix autodoc_member_order="bysource" doesn't work for async methods.

--- a/newsfragments/13.bugfix.rst
+++ b/newsfragments/13.bugfix.rst
@@ -1,1 +1,1 @@
-Fix autodoc_member_order="bysource" doesn't work for async methods.
+Previously, ``autodoc_member_order="bysource"`` didn't work correctly for async methods. Now it does.

--- a/newsfragments/14.removal.rst
+++ b/newsfragments/14.removal.rst
@@ -1,0 +1,1 @@
+Remove support for sphinx<1.6.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 #    customize this)
 # - At release time after bumping version number, run: towncrier
 #   (or towncrier --draft)
-package = "sphinxcontrib-trio"
+package = "sphinxcontrib_trio"
 filename = "docs/source/index.rst"
 directory = "newsfragments"
 underlines = ["+", "~", "^"]

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -380,8 +380,7 @@ def setup(app):
     # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
     from sphinx.pycode.parser import VariableCommentPicker
 
-    # pragma: no cover
-    if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):
+    if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):  # pragma: no cover
         VariableCommentPicker.visit_AsyncFunctionDef = VariableCommentPicker.visit_FunctionDef
 
     return {'version': __version__, 'parallel_read_safe': True}

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -376,4 +376,11 @@ def setup(app):
     del directives._directives["automethod"]
     app.add_autodocumenter(ExtendedFunctionDocumenter)
     app.add_autodocumenter(ExtendedMethodDocumenter)
+
+    # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
+    from sphinx.pycode.parser import VariableCommentPicker
+
+    if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):
+        VariableCommentPicker.visit_AsyncFunctionDef = VariableCommentPicker.visit_FunctionDef
+
     return {'version': __version__, 'parallel_read_safe': True}

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -380,6 +380,7 @@ def setup(app):
     # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
     from sphinx.pycode.parser import VariableCommentPicker
 
+    # pragma: no cover
     if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):
         VariableCommentPicker.visit_AsyncFunctionDef = VariableCommentPicker.visit_FunctionDef
 

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -380,7 +380,7 @@ def setup(app):
     # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
     from sphinx.pycode.parser import VariableCommentPicker
 
-    if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):  # pragma: no cover
+    if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):  # pragma: no branch
         VariableCommentPicker.visit_AsyncFunctionDef = VariableCommentPicker.visit_FunctionDef
 
     return {'version': __version__, 'parallel_read_safe': True}

--- a/tests/test-docs-source/autodoc_examples.py
+++ b/tests/test-docs-source/autodoc_examples.py
@@ -31,5 +31,19 @@ class ExampleClass(abc.ABC):
         pass
 
 
+class ExampleClassForOrder:
+    async def d_asyncmethod(self):
+        pass
+
+    def a_syncmethod(self):
+        pass
+
+    async def c_asyncmethod(self):
+        pass
+
+    def b_syncmethod(self):
+        pass
+
+
 async def autosummary_me():
     pass

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -260,6 +260,15 @@ from you, and (b) you have to integrate correctly with autodoc for
       <em class="property">await </em><code class="descname">asyncmethod</code>
 
 
+Autodoc + order by source:
+
+.. note::
+
+   .. autoclass:: ExampleClassForOrder
+      :members:
+      :undoc-members:
+
+
 Autodoc + explicit options:
 
 .. note::

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -262,11 +262,9 @@ from you, and (b) you have to integrate correctly with autodoc for
 
 Autodoc + order by source:
 
-.. note::
-
-   .. autoclass:: ExampleClassForOrder
-      :members:
-      :undoc-members:
+.. autoclass:: ExampleClassForOrder
+   :members:
+   :undoc-members:
 
 
 Autodoc + explicit options:

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -223,7 +223,7 @@ def test_member_order(tmpdir):
                     str(tmpdir / "test-docs-source"))
 
     subprocess.run(
-        ["sphinx-build", "-v", "-nW", "-D", "autodoc_member_order='bysource'", "-nb", "html",
+        ["sphinx-build", "-v", "-nW", "-D", "autodoc_member_order=bysource", "-nb", "html",
          str(tmpdir / "test-docs-source"), str(tmpdir / "out")])
 
     tree = lxml.html.parse(str(tmpdir / "out" / "test.html")).getroot()

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -223,7 +223,7 @@ def test_member_order(tmpdir):
                     str(tmpdir / "test-docs-source"))
 
     subprocess.run(
-        ["sphinx-build", "-v", "-nW", "-D autodoc_member_order='bysource'", "-nb", "html",
+        ["sphinx-build", "-v", "-nW", "-D 'autodoc_member_order'='bysource'", "-nb", "html",
          str(tmpdir / "test-docs-source"), str(tmpdir / "out")])
 
     tree = lxml.html.parse(str(tmpdir / "out" / "test.html")).getroot()

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -223,7 +223,7 @@ def test_member_order(tmpdir):
                     str(tmpdir / "test-docs-source"))
 
     subprocess.run(
-        ["sphinx-build", "-v", "-nW", "-D 'autodoc_member_order'='bysource'", "-nb", "html",
+        ["sphinx-build", "-v", "-nW", "-D", "autodoc_member_order='bysource'", "-nb", "html",
          str(tmpdir / "test-docs-source"), str(tmpdir / "out")])
 
     tree = lxml.html.parse(str(tmpdir / "out" / "test.html")).getroot()

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -216,3 +216,22 @@ def test_end_to_end(tmpdir):
 
     for note in tree.cssselect(".note"):
         do_html_test(note)
+
+
+def test_member_order(tmpdir):
+    shutil.copytree(str(Path(__file__).parent / "test-docs-source"),
+                    str(tmpdir / "test-docs-source"))
+
+    subprocess.run(
+        ["sphinx-build", "-v", "-nW", "-D autodoc_member_order='bysource'", "-nb", "html",
+         str(tmpdir / "test-docs-source"), str(tmpdir / "out")])
+
+    tree = lxml.html.parse(str(tmpdir / "out" / "test.html")).getroot()
+
+    print("\n-- test case member order by source. --\n")
+
+    methods = tree.cssselect(r"#autodoc_examples\.ExampleClassForOrder")[0].getnext().cssselect("dt")
+
+    names = [method.get("id").split(".")[-1] for method in methods]
+
+    assert names == ["d_asyncmethod", "a_syncmethod", "c_asyncmethod", "b_syncmethod"]


### PR DESCRIPTION
I have tested this PR on your `autodoc_examples.py`.

But I didn't add some tests about it. Not sure is it needed or not.