### PR TITLE
added heuristic for asynccontextmanager

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -120,11 +120,11 @@ Autodetection heuristics
 
 * ``:async-with:`` is autodetected for:
 
-  * functions that have an attribute ``__returns_acontextmanager__`` 
-    (note the ``a``) with a truthy value.
-  
   * functions decorated with `contextlib.asynccontextmanager
     <https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager>`__
+
+  * functions that have an attribute ``__returns_acontextmanager__`` 
+    (note the ``a``) with a truthy value.
 
 * ``:for:`` is autodetected for generators.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -118,9 +118,13 @@ Autodetection heuristics
   * functions that have an attribute ``__returns_contextmanager__``
     with a truthy value.
 
-* ``:async-with:`` is autodetected for functions that have an
-  attribute ``__returns_acontextmanager__`` (note the ``a``) with a
-  truthy value.
+* ``:async-with:`` is autodetected for:
+
+  * functions that have an attribute ``__returns_acontextmanager__`` 
+    (note the ``a``) with a truthy value.
+  
+  * functions decorated with `contextlib.asynccontextmanager
+    <https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager>`__
 
 * ``:for:`` is autodetected for generators.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,7 +121,7 @@ Autodetection heuristics
 * ``:async-with:`` is autodetected for:
 
   * functions decorated with `contextlib.asynccontextmanager
-    <https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager>`__
+    <https://docs.python.org/3/library/contextlib.html#contextlib.asynccontextmanager>`__,
 
   * functions that have an attribute ``__returns_acontextmanager__`` 
     (note the ``a``) with a truthy value.

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -88,6 +88,7 @@ except ImportError:
             return False
 
 CM_CODES = set()
+ACM_CODES = set()
 
 from contextlib import contextmanager
 CM_CODES.add(contextmanager(None).__code__)
@@ -98,6 +99,13 @@ except ImportError:
     pass
 else:
     CM_CODES.add(contextmanager2(None).__code__)
+
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    pass
+else:
+    ACM_CODES.add(asynccontextmanager(None).__code__)
 
 extended_function_option_spec = {
     "async": directives.flag,
@@ -264,6 +272,8 @@ def sniff_options(obj):
                 options.add("with")
             if getattr(obj, "__returns_contextmanager__", False):
                 options.add("with")
+            if getattr(obj, "__code__", None) in ACM_CODES:
+                options.add("async-with")
             if getattr(obj, "__returns_acontextmanager__", False):
                 options.add("async-with")
         if hasattr(obj, "__wrapped__"):

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -27,6 +27,13 @@ except ImportError:
 else:
     have_async_generator = True
 
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    have_asynccontextmanager = False
+else:
+    have_asynccontextmanager = True
+
 from sphinxcontrib_trio import sniff_options
 
 if sys.version_info >= (3, 6):
@@ -135,6 +142,13 @@ def test_sniff_options():
         acm_wrapped.__returns_acontextmanager__ = True
 
         check(acm_wrapped, "async-with")
+
+    if have_asynccontextmanager:
+        @asynccontextmanager
+        async def acm():  # pragma: no cover
+            yield ''
+
+        check(acm, "async-with")
 
     # A chain with complex overrides. We ignore the intermediate generator and
     # async function, because the outermost one is a contextmanager -- but we

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -146,7 +146,7 @@ def test_sniff_options():
     if have_asynccontextmanager:
         @asynccontextmanager
         async def acm():  # pragma: no cover
-            yield_()
+            pass
 
         check(acm, "async-with")
 

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -146,7 +146,7 @@ def test_sniff_options():
     if have_asynccontextmanager:
         @asynccontextmanager
         async def acm():  # pragma: no cover
-            yield ''
+            yield_()
 
         check(acm, "async-with")
 

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -144,10 +144,7 @@ def test_sniff_options():
         check(acm_wrapped, "async-with")
 
     if have_asynccontextmanager:
-        @asynccontextmanager
-        async def acm():  # pragma: no cover
-            pass
-
+        acm = asynccontextmanager(agen_native)
         check(acm, "async-with")
 
     # A chain with complex overrides. We ignore the intermediate generator and


### PR DESCRIPTION
Hi!
I had a problem with contextmanagers using the @asynccontextmanager decorator from contextlib being detected as async generators. So I added the same type of heuristic that is used for normal ccontextmanagers to detect asynccontextmanager.

I also updated the documentation and the testcases to cover this.