### PR TITLE
Properly resolve MRO entires for subclassed methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,8 @@ coverage.xml
 *.log
 *.pot
 
+# MyPy stuff:
+.mypy_cache
+
 # Sphinx documentation
 doc/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ coverage.xml
 *.log
 *.pot
 
+# VSCode stuff:
+.vscode
+
 # MyPy stuff:
 .mypy_cache
 

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -65,7 +65,7 @@ try:
     from sphinx.domains.python import PyFunction
 except ImportError:
     from sphinx.domains.python import PyModulelevel as PyFunction
-from sphinx.domains.python import PyClassmember
+from sphinx.domains.python import PyClassmember, PyObject
 from sphinx.ext.autodoc import (
     FunctionDocumenter, MethodDocumenter, ClassLevelDocumenter, Options, ModuleLevelDocumenter
 )
@@ -85,21 +85,21 @@ CM_CODES = set()
 ACM_CODES = set()
 
 from contextlib import contextmanager
-CM_CODES.add(contextmanager(None).__code__)
+CM_CODES.add(contextmanager(None).__code__)  # type: ignore
 
 try:
     from contextlib2 import contextmanager as contextmanager2
 except ImportError:
     pass
 else:
-    CM_CODES.add(contextmanager2(None).__code__)
+    CM_CODES.add(contextmanager2(None).__code__)  # type: ignore
 
 try:
     from contextlib import asynccontextmanager
 except ImportError:
     pass
 else:
-    ACM_CODES.add(asynccontextmanager(None).__code__)
+    ACM_CODES.add(asynccontextmanager(None).__code__)  # type: ignore
 
 extended_function_option_spec = {
     "async": directives.flag,
@@ -127,7 +127,7 @@ autodoc_option_spec = {
 ################################################################
 
 
-class ExtendedCallableMixin:
+class ExtendedCallableMixin(PyObject):  # inherit PyObject to satisfy MyPy
     def needs_arglist(self):
         if "property" in self.options:
             return False
@@ -405,6 +405,10 @@ def setup(app):
     # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
     from sphinx.pycode.parser import VariableCommentPicker
     if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):  # pragma: no branch
-        VariableCommentPicker.visit_AsyncFunctionDef = VariableCommentPicker.visit_FunctionDef
+        setattr(
+            VariableCommentPicker,
+            "visit_AsyncFunctionDef",
+            VariableCommentPicker.visit_FunctionDef,
+        )
 
     return {'version': __version__, 'parallel_read_safe': True}

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -126,6 +126,7 @@ autodoc_option_spec = {
 # Extending the basic function and method directives
 ################################################################
 
+
 class ExtendedCallableMixin:
     def needs_arglist(self):
         if "property" in self.options:
@@ -212,11 +213,13 @@ class ExtendedCallableMixin:
 
         return ret
 
+
 class ExtendedPyFunction(ExtendedCallableMixin, PyFunction):
     option_spec = {
         **PyFunction.option_spec,
         **extended_function_option_spec,
     }
+
 
 class ExtendedPyMethod(ExtendedCallableMixin, PyClassmember):
     option_spec = {
@@ -238,6 +241,7 @@ class ExtendedPyMethod(ExtendedCallableMixin, PyClassmember):
 # contextlib.contextmanager). So once we see one of these, we stop looking for
 # the others.
 EXCLUSIVE_OPTIONS = {"async", "for", "async-for", "with", "async-with"}
+
 
 def sniff_options(obj):
     options = set()
@@ -279,6 +283,7 @@ def sniff_options(obj):
 
     return options
 
+
 def update_with_sniffed_options(obj, option_dict):
     if "no-auto-options" in option_dict:
         return
@@ -293,6 +298,7 @@ def update_with_sniffed_options(obj, option_dict):
         # with our autodetected attr["for"] = None. So we use setdefault.
         option_dict.setdefault(attr, None)
 
+
 def passthrough_option_lines(self, option_spec):
     sourcename = self.get_sourcename()
     for option in option_spec:
@@ -302,6 +308,7 @@ def passthrough_option_lines(self, option_spec):
             else:
                 line = "   :{}:".format(option)
             self.add_line(line, sourcename)
+
 
 class ExtendedFunctionDocumenter(FunctionDocumenter):
     priority = FunctionDocumenter.priority + 1
@@ -326,6 +333,7 @@ class ExtendedFunctionDocumenter(FunctionDocumenter):
         self.options = Options(self.options)
         update_with_sniffed_options(self.object, self.options)
         return ret
+
 
 class ExtendedMethodDocumenter(MethodDocumenter):
     priority = MethodDocumenter.priority + 1
@@ -376,6 +384,7 @@ class ExtendedMethodDocumenter(MethodDocumenter):
 ################################################################
 # Register everything
 ################################################################
+
 
 def setup(app):
     app.add_directive_to_domain('py', 'function', ExtendedPyFunction)

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -357,21 +357,9 @@ class ExtendedMethodDocumenter(MethodDocumenter):
         # addition to just importing. But we do our own sniffing and just want
         # the import, so we un-override it.
         ret = ClassLevelDocumenter.import_object(self)
-        # If you have a classmethod or staticmethod, then
-        #
-        #   Class.__dict__["name"]
-        #
-        # returns the classmethod/staticmethod object, but
-        #
-        #   getattr(Class, "name")
-        #
-        # returns a regular function. We want to detect
-        # classmethod/staticmethod, so we need to go through __dict__.
-        # Not using 'getattr' here means we have to manually resolve the MRO entires too.
-        for cls in inspect.getmro(self.parent):
-            obj = cls.__dict__.get(self.object_name)
-            if obj is not None:
-                break
+        # Use 'inspect.getattr_static' to properly detect class or static methods.
+        # This also resolves the MRO entries for subclasses.
+        obj = inspect.getattr_static(self.parent, self.object_name)
         # autodoc likes to re-use dicts here for some reason (!?!)
         self.options = Options(self.options)
         update_with_sniffed_options(obj, self.options)

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -359,7 +359,11 @@ class ExtendedMethodDocumenter(MethodDocumenter):
         #
         # returns a regular function. We want to detect
         # classmethod/staticmethod, so we need to go through __dict__.
-        obj = self.parent.__dict__.get(self.object_name)
+        # Not using 'getattr' here means we have to manually resolve the MRO entires too.
+        for cls in inspect.getmro(self.parent):
+            obj = cls.__dict__.get(self.object_name)
+            if obj is not None:
+                break
         # autodoc likes to re-use dicts here for some reason (!?!)
         self.options = Options(self.options)
         update_with_sniffed_options(obj, self.options)

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -393,10 +393,8 @@ def setup(app):
     # A monkey-patch to VariableCommentPicker to make autodoc_member_order = 'bysource' work.
     from sphinx.pycode.parser import VariableCommentPicker
     if not hasattr(VariableCommentPicker, "visit_AsyncFunctionDef"):  # pragma: no branch
-        setattr(
-            VariableCommentPicker,
-            "visit_AsyncFunctionDef",
-            VariableCommentPicker.visit_FunctionDef,
+        VariableCommentPicker.visit_AsyncFunctionDef = (  # type: ignore
+            VariableCommentPicker.visit_FunctionDef  # type: ignore
         )
 
     return {'version': __version__, 'parallel_read_safe': True}

--- a/tests/test-docs-source/autodoc_examples.py
+++ b/tests/test-docs-source/autodoc_examples.py
@@ -1,10 +1,13 @@
 import abc
 
+
 def basic():
     pass
 
+
 async def asyncfn(x):
     pass
+
 
 def gen():
     yield
@@ -12,6 +15,7 @@ def gen():
 # Classes are a bit complicated for autodoc, because:
 # - there's the :members: option
 # - how you access the attributes matters
+
 
 class ExampleClass(abc.ABC):
     @abc.abstractmethod
@@ -34,6 +38,7 @@ class ExampleClass(abc.ABC):
     def property_(self):
         pass
 
+
 class ExampleClassForOrder:
     async def d_asyncmethod(self):
         pass
@@ -45,6 +50,14 @@ class ExampleClassForOrder:
         pass
 
     def b_syncmethod(self):
+        pass
+
+
+class ExampleInheritedSubclass(ExampleClassForOrder):
+    def a_syncmethod(self):
+        pass
+
+    async def c_asyncmethod(self):
         pass
 
 

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -279,6 +279,8 @@ Autodoc + order by source:
    :members:
    :undoc-members:
 
+Autodoc + inherited methods:
+
 .. note::
 
    .. autoclass:: ExampleInheritedSubclass
@@ -288,19 +290,26 @@ Autodoc + order by source:
 
    .. code-block:: none
 
-      <code class="(sig-name )?descname">a_syncmethod</code>
-
-   .. code-block:: none
-
-      <code class="(sig-name )?descname">b_syncmethod</code>
-
-   .. code-block:: none
-
       <em class="property">await </em><code class="(sig-name )?descname">c_asyncmethod</code>
 
    .. code-block:: none
 
       <em class="property">await </em><code class="(sig-name )?descname">d_asyncmethod</code>
+
+.. warning::
+
+   .. autoclass:: ExampleInheritedSubclass
+      :members:
+      :undoc-members:
+      :inherited-members:
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">a_syncmethod</code>
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">b_syncmethod</code>
 
 
 Autodoc + explicit options:

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -283,14 +283,16 @@ Autodoc + order by source:
 
    .. autoclass:: ExampleInheritedSubclass
       :members:
+      :undoc-members:
+      :inherited-members:
 
    .. code-block:: none
 
-      <em class="property">await </em><code class="(sig-name )?descname">a_syncmethod</code>
+      <code class="(sig-name )?descname">a_syncmethod</code>
 
    .. code-block:: none
 
-      <em class="property">await </em><code class="(sig-name )?descname">b_syncmethod</code>
+      <code class="(sig-name )?descname">b_syncmethod</code>
 
    .. code-block:: none
 

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -307,6 +307,13 @@ Autodoc + inherited methods:
 
       <em class="property">await </em><code class="(sig-name )?descname">a_syncmethod</code>
 
+.. warning::
+
+   .. autoclass:: ExampleInheritedSubclass
+      :members:
+      :undoc-members:
+      :inherited-members:
+
    .. code-block:: none
 
       <em class="property">await </em><code class="(sig-name )?descname">b_syncmethod</code>

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -4,7 +4,7 @@
 
 Each ``note`` in this file is a test case. The ``test_end_to_end``
 function in ``test_sphinxcontrib_trio.py`` loops through the rendered
-output of each ``note``, and for eacn one it finds all the "none"
+output of each ``note``, and for each one it finds all the "none"
 code-blocks, and it makes sure that the contents of that code-block
 appears in the html source for the rest of the note.
 
@@ -278,6 +278,27 @@ Autodoc + order by source:
 .. autoclass:: ExampleClassForOrder
    :members:
    :undoc-members:
+
+.. note::
+
+   .. autoclass:: ExampleInheritedSubclass
+      :members:
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">a_syncmethod</code>
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">b_syncmethod</code>
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">c_asyncmethod</code>
+
+   .. code-block:: none
+
+      <em class="property">await </em><code class="(sig-name )?descname">d_asyncmethod</code>
 
 
 Autodoc + explicit options:

--- a/tests/test-docs-source/test.rst
+++ b/tests/test-docs-source/test.rst
@@ -307,13 +307,6 @@ Autodoc + inherited methods:
 
       <em class="property">await </em><code class="(sig-name )?descname">a_syncmethod</code>
 
-.. warning::
-
-   .. autoclass:: ExampleInheritedSubclass
-      :members:
-      :undoc-members:
-      :inherited-members:
-
    .. code-block:: none
 
       <em class="property">await </em><code class="(sig-name )?descname">b_syncmethod</code>

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -154,19 +154,25 @@ def test_sniff_options():
     # A chain with complex overrides. We ignore the intermediate generator and
     # async function, because the outermost one is a contextmanager -- but we
     # still pick up the staticmethod at the end of the chain.
-    @staticmethod
+    @staticmethod  # type: ignore
     def messy0():  # pragma: no cover
         pass
+
     async def messy1():  # pragma: no cover
         pass
-    messy1.__wrapped__ = messy0
+
+    setattr(messy1, "__wrapped__", messy0)
+
     def messy2():  # pragma: no cover
         yield
-    messy2.__wrapped__ = messy1
+
+    setattr(messy2, "__wrapped__", messy1)
+
     def messy3():  # pragma: no cover
         pass
-    messy3.__wrapped__ = messy2
-    messy3.__returns_contextmanager__ = True
+
+    setattr(messy3, "__wrapped__", messy2)
+    setattr(messy3, "__returns_contextmanager__", True)
     check(messy3, "with", "staticmethod")
 
 

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -1,15 +1,14 @@
-import pytest
-
-import subprocess
-import sys
-import textwrap
-import abc
-from contextlib import contextmanager
-from functools import wraps
-import shutil
-from pathlib import Path
 import re
+import abc
+import sys
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+from functools import wraps
+from contextlib import contextmanager
 
+import pytest
 import lxml.html
 
 try:

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -1,13 +1,11 @@
 import pytest
 
 import subprocess
-import os.path
 import sys
 import textwrap
 import abc
 from contextlib import contextmanager
 from functools import wraps
-import difflib
 import shutil
 from pathlib import Path
 import re
@@ -42,6 +40,7 @@ if sys.version_info >= (3, 6):
         async def agen_native():
             yield
     """))
+
 
 def test_sniff_options():
     def check(obj, *expected):
@@ -165,6 +164,7 @@ def test_sniff_options():
     messy3.__wrapped__ = messy2
     messy3.__returns_contextmanager__ = True
     check(messy3, "with", "staticmethod")
+
 
 # Hopefully the next sphinx release will have dedicated pytest-based testing
 # utilities:

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -56,7 +56,7 @@ def test_sniff_options():
             pass
 
         @classmethod
-        def b(self):
+        def b(cls):
             pass
 
         @staticmethod
@@ -64,7 +64,7 @@ def test_sniff_options():
             pass
 
         @classmethod
-        async def classasync(self):
+        async def classasync(cls):
             pass
 
     check(Basic.__dict__["a"])

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -127,12 +127,12 @@ def test_sniff_options():
 
     def manual_cm():  # pragma: no cover
         pass
-    setattr(manual_cm, "__returns_contextmanager__", True)
+    manual_cm.__returns_contextmanager__ = True  # type: ignore
     check(manual_cm, "with")
 
     def manual_acm():  # pragma: no cover
         pass
-    setattr(manual_acm, "__returns_acontextmanager__", True)
+    manual_acm.__returns_acontextmanager__ = True  # type: ignore
     check(manual_acm, "async-with")
 
     if have_async_generator:
@@ -143,7 +143,7 @@ def test_sniff_options():
         @wraps(acm_gen)
         def acm_wrapped():  # pragma: no cover
             pass
-        setattr(acm_wrapped, "__returns_acontextmanager__", True)
+        acm_wrapped.__returns_acontextmanager__ = True  # type: ignore
 
         check(acm_wrapped, "async-with")
 
@@ -161,18 +161,18 @@ def test_sniff_options():
     async def messy1():  # pragma: no cover
         pass
 
-    setattr(messy1, "__wrapped__", messy0)
+    messy1.__wrapped__ = messy0  # type: ignore
 
     def messy2():  # pragma: no cover
         yield
 
-    setattr(messy2, "__wrapped__", messy1)
+    messy2.__wrapped__ = messy1  # type: ignore
 
     def messy3():  # pragma: no cover
         pass
 
-    setattr(messy3, "__wrapped__", messy2)
-    setattr(messy3, "__returns_contextmanager__", True)
+    messy3.__wrapped__ = messy2  # type: ignore
+    messy3.__returns_contextmanager__ = True  # type: ignore
     check(messy3, "with", "staticmethod")
 
 

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -6,8 +6,8 @@ import inspect
 import textwrap
 import subprocess
 from pathlib import Path
-from typing import Callable
 from functools import wraps
+from typing import Callable, cast
 from contextlib import contextmanager
 
 import pytest
@@ -37,7 +37,7 @@ else:
 from sphinxcontrib_trio import sniff_options
 
 if sys.version_info >= (3, 6):
-    agen_native: Callable = lambda: None  # satisfy linter
+    agen_native = cast(Callable, lambda: None)  # satisfy linter
     exec(textwrap.dedent("""
         async def agen_native():
             yield

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -2,9 +2,11 @@ import re
 import abc
 import sys
 import shutil
-import subprocess
+import inspect
 import textwrap
+import subprocess
 from pathlib import Path
+from typing import Callable
 from functools import wraps
 from contextlib import contextmanager
 
@@ -35,6 +37,7 @@ else:
 from sphinxcontrib_trio import sniff_options
 
 if sys.version_info >= (3, 6):
+    agen_native: Callable = lambda: None  # satisfy linter
     exec(textwrap.dedent("""
         async def agen_native():
             yield
@@ -122,12 +125,12 @@ def test_sniff_options():
 
     def manual_cm():  # pragma: no cover
         pass
-    manual_cm.__returns_contextmanager__ = True
+    setattr(manual_cm, "__returns_contextmanager__", True)
     check(manual_cm, "with")
 
     def manual_acm():  # pragma: no cover
         pass
-    manual_acm.__returns_acontextmanager__ = True
+    setattr(manual_acm, "__returns_acontextmanager__", True)
     check(manual_acm, "async-with")
 
     if have_async_generator:
@@ -138,7 +141,7 @@ def test_sniff_options():
         @wraps(acm_gen)
         def acm_wrapped():  # pragma: no cover
             pass
-        acm_wrapped.__returns_acontextmanager__ = True
+        setattr(acm_wrapped, "__returns_acontextmanager__", True)
 
         check(acm_wrapped, "async-with")
 
@@ -241,7 +244,9 @@ def test_member_order(tmpdir):
 
     print("\n-- test case member order by source. --\n")
 
-    methods = tree.cssselect(r"#autodoc_examples\.ExampleClassForOrder")[0].getnext().cssselect("dt")
+    methods = (
+        tree.cssselect(r"#autodoc_examples\.ExampleClassForOrder")[0].getnext().cssselect("dt")
+    )
 
     names = [method.get("id").split(".")[-1] for method in methods]
 

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -69,10 +69,10 @@ def test_sniff_options():
         async def classasync(cls):
             pass
 
-    check(Basic.__dict__["a"])
-    check(Basic.__dict__["b"], "classmethod")
-    check(Basic.__dict__["c"], "staticmethod")
-    check(Basic.__dict__["classasync"], "classmethod", "async")
+    check(inspect.getattr_static(Basic, "a"))
+    check(inspect.getattr_static(Basic, "b"), "classmethod")
+    check(inspect.getattr_static(Basic, "c"), "staticmethod")
+    check(inspect.getattr_static(Basic, "classasync"), "classmethod", "async")
 
     class Abstract(abc.ABC):  # pragma: no cover
         @abc.abstractmethod
@@ -89,10 +89,11 @@ def test_sniff_options():
         async def abstaticasync(self):
             pass
 
-    check(Abstract.__dict__["abmeth"], "abstractmethod")
-    check(Abstract.__dict__["abstatic"], "abstractmethod", "staticmethod")
-    check(Abstract.__dict__["abstaticasync"],
-          "abstractmethod", "staticmethod", "async")
+    check(inspect.getattr_static(Basic, "abmeth"), "abstractmethod")
+    check(inspect.getattr_static(Basic, "abstatic"), "abstractmethod", "staticmethod")
+    check(
+        inspect.getattr_static(Basic, "abstaticasync"), "abstractmethod", "staticmethod", "async"
+    )
 
     async def async_fn():  # pragma: no cover
         pass

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -194,7 +194,7 @@ def test_end_to_end(tmpdir):
 
     def do_html_test(node):
         original_content = node.text_content()
-        print("-- test case --\n", lxml.html.tostring(node, encoding="unicode"))
+        print("\n-- test case --\n", lxml.html.tostring(node, encoding="unicode"))
 
         check_tags = node.cssselect(".highlight-none")
         checks = []

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -192,7 +192,7 @@ def test_end_to_end(tmpdir):
 
     tree = lxml.html.parse(str(tmpdir / "out" / "test.html")).getroot()
 
-    def do_html_test(node):
+    def do_html_test(node, *, expect_match):
         original_content = node.text_content()
         print("\n-- test case --\n", lxml.html.tostring(node, encoding="unicode"))
 
@@ -217,7 +217,10 @@ def test_end_to_end(tmpdir):
         test_content = test_content.replace("\u2026", "...")
         for check in checks:
             try:
-                assert re.search(check, test_content) is not None
+                if expect_match:
+                    assert re.search(check, test_content) is not None
+                else:
+                    assert re.search(check, test_content) is None
             except AssertionError:
                 print("failed check")
                 print()
@@ -231,13 +234,12 @@ def test_end_to_end(tmpdir):
     print("\n-- NEGATIVE (WARNING) TESTS --\n")
 
     for warning in tree.cssselect(".warning"):
-        with pytest.raises(AssertionError):
-            do_html_test(warning)
+        do_html_test(warning, expect_match=False)
 
     print("\n-- POSITIVE (NOTE) TESTS --\n")
 
     for note in tree.cssselect(".note"):
-        do_html_test(note)
+        do_html_test(note, expect_match=True)
 
 
 def test_member_order(tmpdir):

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -89,10 +89,11 @@ def test_sniff_options():
         async def abstaticasync(self):
             pass
 
-    check(inspect.getattr_static(Basic, "abmeth"), "abstractmethod")
-    check(inspect.getattr_static(Basic, "abstatic"), "abstractmethod", "staticmethod")
+    check(inspect.getattr_static(Abstract, "abmeth"), "abstractmethod")
+    check(inspect.getattr_static(Abstract, "abstatic"), "abstractmethod", "staticmethod")
     check(
-        inspect.getattr_static(Basic, "abstaticasync"), "abstractmethod", "staticmethod", "async"
+        inspect.getattr_static(Abstract, "abstaticasync"),
+        "abstractmethod", "staticmethod", "async",
     )
 
     async def async_fn():  # pragma: no cover

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -208,7 +208,7 @@ def test_end_to_end(tmpdir):
         for check in checks:
             try:
                 assert re.search(check, test_content) is not None
-            except:
+            except AssertionError:
                 print("failed check")
                 print()
                 print(repr(check))

--- a/tests/test_sphinxcontrib_trio.py
+++ b/tests/test_sphinxcontrib_trio.py
@@ -10,7 +10,6 @@ from functools import wraps
 from typing import Callable, cast
 from contextlib import contextmanager
 
-import pytest
 import lxml.html
 
 try:


### PR DESCRIPTION
The cause has been detected and explained by me in #19. The issue was that accessing the `__dict__` on a class directly, didn't resolve MRO entires in any way, so it was just returning `None` for any inherited method (since those are normally accessed after resolving).

Please note that I've ran exactly 0 tests for this, other than trying it out on my documentation (it works beautifully there), but you can deduce from the code that this change shouldn't break anything (that wasn't already broken).

Fixes #19.