### PR TITLE
Fix Sphinx 3.0 warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,22 @@ language: python
 dist: xenial
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.7
       env: OLD_SPHINX=1.7
-    - python: 3.7
+    - python: 3.8
       env: OLD_SPHINX=1.8
-    - python: 3.7
+    - python: 3.8
       env: OLD_SPHINX=2.0
+    - python: 3.8
+      env: OLD_SPHINX=2.1
+    - python: 3.8
+      env: OLD_SPHINX=2.2
+    - python: 3.8
+      env: OLD_SPHINX=2.3
+    - python: 3.8
+      env: OLD_SPHINX=2.4
 
 script:
   - ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 dist: xenial
 matrix:
   include:
+    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     url="https://github.com/python-trio/sphinxcontrib-trio",
-    install_requires=["sphinx >= 1.7"],
+    install_requires=["sphinx >= 3.0"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     license="MIT -or- Apache License 2.0",
     packages=find_packages(),
     url="https://github.com/python-trio/sphinxcontrib-trio",
-    install_requires=["sphinx >= 3.0"],
+    install_requires=["sphinx >= 1.7"],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         "Intended Audience :: Developers",

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -65,7 +65,13 @@ try:
     from sphinx.domains.python import PyFunction
 except ImportError:
     from sphinx.domains.python import PyModulelevel as PyFunction
-from sphinx.domains.python import PyMethod, PyClassMethod, PyStaticMethod, PyObject
+from sphinx.domains.python import PyObject
+try:
+    from sphinx.domains.python import PyMethod, PyClassMethod, PyStaticMethod
+except ImportError:
+    from sphinx.domains.python import PyClassmember as PyMethod
+    from sphinx.domains.python import PyClassmember as PyClassMethod
+    from sphinx.domains.python import PyClassmember as PyStaticMethod
 from sphinx.ext.autodoc import (
     FunctionDocumenter, MethodDocumenter, ClassLevelDocumenter, Options, ModuleLevelDocumenter
 )

--- a/sphinxcontrib_trio/__init__.py
+++ b/sphinxcontrib_trio/__init__.py
@@ -65,7 +65,7 @@ try:
     from sphinx.domains.python import PyFunction
 except ImportError:
     from sphinx.domains.python import PyModulelevel as PyFunction
-from sphinx.domains.python import PyClassmember, PyObject
+from sphinx.domains.python import PyMethod, PyClassMethod, PyStaticMethod, PyObject
 from sphinx.ext.autodoc import (
     FunctionDocumenter, MethodDocumenter, ClassLevelDocumenter, Options, ModuleLevelDocumenter
 )
@@ -221,9 +221,23 @@ class ExtendedPyFunction(ExtendedCallableMixin, PyFunction):
     }
 
 
-class ExtendedPyMethod(ExtendedCallableMixin, PyClassmember):
+class ExtendedPyMethod(ExtendedCallableMixin, PyMethod):
     option_spec = {
-        **PyClassmember.option_spec,
+        **PyMethod.option_spec,
+        **extended_method_option_spec,
+    }
+
+
+class ExtendedPyClassMethod(ExtendedCallableMixin, PyClassMethod):
+    option_spec = {
+        **PyClassMethod.option_spec,
+        **extended_method_option_spec,
+    }
+
+
+class ExtendedPyStaticMethod(ExtendedCallableMixin, PyStaticMethod):
+    option_spec = {
+        **PyStaticMethod.option_spec,
         **extended_method_option_spec,
     }
 
@@ -377,8 +391,8 @@ class ExtendedMethodDocumenter(MethodDocumenter):
 def setup(app):
     app.add_directive_to_domain('py', 'function', ExtendedPyFunction)
     app.add_directive_to_domain('py', 'method', ExtendedPyMethod)
-    app.add_directive_to_domain('py', 'classmethod', ExtendedPyMethod)
-    app.add_directive_to_domain('py', 'staticmethod', ExtendedPyMethod)
+    app.add_directive_to_domain('py', 'classmethod', ExtendedPyClassMethod)
+    app.add_directive_to_domain('py', 'staticmethod', ExtendedPyStaticMethod)
     app.add_directive_to_domain('py', 'decorator', ExtendedPyFunction)
     app.add_directive_to_domain('py', 'decoratormethod', ExtendedPyMethod)
 


### PR DESCRIPTION
PyClassMember has been split into various methods. This fixes the following warnings in https://github.com/python-trio/trio/pull/1465:

> /opt/hostedtoolcache/Python/3.8.2/x64/lib/python3.8/site-packages/sphinx/domains/python.py:659: RemovedInSphinx40Warning: PyClassmember is deprecated. Please check the implementation of <class 'sphinxcontrib_trio.ExtendedPyMethod'>