### PR TITLE
Replace call to add_stylesheet with add_css_file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ extensions = [
 ]
 
 def setup(app):
-    app.add_stylesheet("hack.css")
+    app.add_css_file("hack.css")
 
 intersphinx_mapping = {
     "sphinx": ("http://www.sphinx-doc.org/en/stable/", None),


### PR DESCRIPTION
This should fix documentation build failures with Sphinx 4.